### PR TITLE
`Puppetfile`: remove default `forge`

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,5 +1,3 @@
-forge "https:--forge.puppet.com"
-
 mod 'cirrax-libvirt', '5.1.0'
 mod 'puppet-archive', '7.1.0'
 mod 'puppet-borg', '4.2.0'


### PR DESCRIPTION
No need for this line since it is the default (and it has a typo, dashes instead of slashes).